### PR TITLE
Update regex and message for campaing join links

### DIFF
--- a/cogs5e/gamelog/cog.py
+++ b/cogs5e/gamelog/cog.py
@@ -50,9 +50,9 @@ class GameLog(commands.Cog):
             return await self.campaign_list(ctx)
 
         link_match = re.match(r"(?:https?://)?(?:www\.|stg\.)?dndbeyond\.com/campaigns/(\d+)(?:$|/)", campaign_link)
-        invite_link_match = re.match(r"(?:https?://)?ddb\.ac/campaigns/join/(\d+)\d{10}(?:$|/)", campaign_link)
+        invite_link_match = re.match(r"(?:https?://)?(?:ddb\.ac|www\.dndbeyond\.com)/campaigns/join/(\d{7})\d+(?:$|/)", campaign_link)
         if link_match is None and invite_link_match is None:
-            return await ctx.send("This is not a D&D Beyond campaign link.")
+            return await ctx.send("Could not process this link. Try using the campaign URL (in your browser bar) rather than the invite link!")
         campaign_id = (link_match or invite_link_match).group(1)
 
         # is there already an existing link?


### PR DESCRIPTION
Error message now explicitly states to use the campaign url rather than the invite link on error.  Invite link regex also updated to allow for www.dndbeyond.com or ac.ddb

### Summary
Update the campaign invite link regex and error message

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
