### PR TITLE
Update character.py

### DIFF
--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -195,6 +195,6 @@ CHARACTER_SETTINGS = {
         "number",
         description="version of the ruleset to use",
         default="2024",
-        display_func=lambda val: "2024" if val == 2024 else "2014",
+        display_func=lambda val: "2024" if val == "2024" else "2014",
     ),
 }


### PR DESCRIPTION
Display correct version number when using `!csettings version`

### Summary
`!csettings version` currently always displays "your version is set to 2014" 

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
